### PR TITLE
POSCAR option and failure on OUTCARs contain "Primitive cell"

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -121,8 +121,8 @@ impl fmt::Display for IonicIterationsFormat {
         let nions = self._data[0].forces.len();
         let dynamics =
             if let Ok(poscar) = Poscar::from_path("POSCAR") {
-                info!("Opened POSCAR and filtering relaxed ions. {}",
-                      "Note: the force info listed below doesn't contains fixed atoms".yellow());
+                info!("POSCAR was read. Filtering relaxed ions... {}",
+                      "Note: the force info listed below doesn't contains fixed atoms");
                 let dynamics = poscar.into_raw().dynamics.unwrap_or(vec![[true; 3]; nions]);
                 assert_eq!(nions, dynamics.len(), "Inconsistent ion numbers from POSCAR and OUTCAR");
                 dynamics

--- a/src/format.rs
+++ b/src/format.rs
@@ -121,6 +121,8 @@ impl fmt::Display for IonicIterationsFormat {
         let nions = self._data[0].forces.len();
         let dynamics =
             if let Ok(poscar) = Poscar::from_path("POSCAR") {
+                info!("Opened POSCAR and filtering relaxed ions. {}",
+                      "Note: the force info listed below doesn't contains fixed atoms".yellow());
                 let dynamics = poscar.into_raw().dynamics.unwrap_or(vec![[true; 3]; nions]);
                 assert_eq!(nions, dynamics.len(), "Inconsistent ion numbers from POSCAR and OUTCAR");
                 dynamics
@@ -159,7 +161,7 @@ impl fmt::Display for IonicIterationsFormat {
 
             let fsize = it.forces.iter()
                                  .zip(dynamics.iter())
-                                 .map(|(f, d)| (f[0]*f[0]*d[0] + f[1]*f[1]*d[1] + f[2]*f[2]*d[1]).sqrt())
+                                 .map(|(f, d)| (f[0]*f[0]*d[0] + f[1]*f[1]*d[1] + f[2]*f[2]*d[2]).sqrt())
                                  .collect::<Vec<_>>();
 
             if self.print_favg {

--- a/src/format.rs
+++ b/src/format.rs
@@ -118,6 +118,19 @@ impl IonicIterationsFormat {
 
 impl fmt::Display for IonicIterationsFormat {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let nions = self._data[0].forces.len();
+        let dynamics =
+            if let Ok(poscar) = Poscar::from_path("POSCAR") {
+                let dynamics = poscar.into_raw().dynamics.unwrap_or(vec![[true; 3]; nions]);
+                assert_eq!(nions, dynamics.len(), "Inconsistent ion numbers from POSCAR and OUTCAR");
+                dynamics
+            } else { vec![[true; 3]; nions] }
+        .into_iter()
+        .map(|v| {
+            [v[0] as i32 as f64, v[1] as i32 as f64, v[2] as i32 as f64]
+        })
+        .collect::<Vec<_>>();
+
         let mut ce: f64 = 0.0;
 
         // Prepare Header
@@ -145,8 +158,9 @@ impl fmt::Display for IonicIterationsFormat {
             if self.print_log10de { line += &format!(" {:4.1}", de.abs().log10()); }
 
             let fsize = it.forces.iter()
-                                   .map(|f| (f[0]*f[0] + f[1]*f[1] + f[2]*f[2]).sqrt())
-                                   .collect::<Vec<_>>();
+                                 .zip(dynamics.iter())
+                                 .map(|(f, d)| (f[0]*f[0]*d[0] + f[1]*f[1]*d[1] + f[2]*f[2]*d[1]).sqrt())
+                                 .collect::<Vec<_>>();
 
             if self.print_favg {
                 line += &format!(" {:6.3}", fsize.iter().sum::<f64>() / it.forces.len() as f64);

--- a/src/format.rs
+++ b/src/format.rs
@@ -122,7 +122,7 @@ impl fmt::Display for IonicIterationsFormat {
         let dynamics =
             if let Ok(poscar) = Poscar::from_path("POSCAR") {
                 info!("POSCAR was read. Filtering relaxed ions... {}",
-                      "Note: the force info listed below doesn't contains fixed atoms");
+                      "Note: the force info listed below doesn't contain fixed atoms");
                 let dynamics = poscar.into_raw().dynamics.unwrap_or(vec![[true; 3]; nions]);
                 assert_eq!(nions, dynamics.len(), "Inconsistent ion numbers from POSCAR and OUTCAR");
                 dynamics

--- a/src/outcar.rs
+++ b/src/outcar.rs
@@ -358,11 +358,10 @@ impl Outcar {
     }
 
     fn parse_opt_cells(context: &str) -> Vec<Mat33<f64>> {
-        let skip_cnt: usize = if context.find(" old parameters").is_some() {
-            2
-        } else {
-            1
-        };
+        let skip_cnt: usize = 1 +
+            context.find(" old parameters").is_some() as usize +
+            context.find("Primitive cell").is_some() as usize;
+
         Regex::new(r"direct lattice vectors")
             .unwrap()
             .find_iter(context)
@@ -850,6 +849,14 @@ mod tests{
      0.000000000  0.000000000  8.000000000     0.000000000  0.000000000  0.125000000
 --
  old parameters found on file WAVECAR:
+      direct lattice vectors                 reciprocal lattice vectors
+     4.001368000  0.000000000  0.000000000     0.249914529  0.000000000  0.000000000
+     0.000000000  4.001368000  0.000000000     0.000000000  0.249914529  0.000000000
+     0.000000000  0.000000000  4.215744000     0.000000000  0.000000000  0.237206054
+--
+                                     Primitive cell
+
+  volume of cell :   47993.5183
       direct lattice vectors                 reciprocal lattice vectors
      4.001368000  0.000000000  0.000000000     0.249914529  0.000000000  0.000000000
      0.000000000  4.001368000  0.000000000     0.000000000  0.249914529  0.000000000


### PR DESCRIPTION
- bugfix: when `OUTCAR` contains "Primitive cell", `rsgrad` may fail
- bugfix: add POSCAR option when a system contains "selective dynamics", which affects the total-force counting.